### PR TITLE
agregando reseteo de variables cuando se cambia de familia

### DIFF
--- a/dist/borrapsi.php
+++ b/dist/borrapsi.php
@@ -1,0 +1,4 @@
+<?php
+session_start();
+$_SESSION['psi'] = 0;
+?>

--- a/dist/crear-nota-pedido-2.php
+++ b/dist/crear-nota-pedido-2.php
@@ -102,6 +102,18 @@ Seguridad::integridadSistema();
     $(document).on('change','#select-familia',function(){
         $("#valueshow").html("0");
         $("#respuesta").html("0");
+        $("#cantidadprod").val("1");
+        $("#descuento-por-producto").val("0");
+        $.ajax({
+		url: 'borrapsi.php',
+		type:'POST',
+		dataType: 'html',
+	
+	})
+	.done(function(){
+        console.log("se blanqueo el psi");
+  
+	})
     
     });
 


### PR DESCRIPTION
Cuando había una cantidad cargada y se cambiaba de familia no se reseteaba la cantidad de productos  y el precio de lo último cargado podía multiplicarse por las unidades. Después de los cambios resetea la cantidad de unidades, descuento y la variable session del precio se blanquea.